### PR TITLE
ドキュメントにgpidの追加

### DIFF
--- a/dev-docs/bidders/microad.md
+++ b/dev-docs/bidders/microad.md
@@ -16,12 +16,16 @@ For more information, visit [MicroAd website](https://www.microad.co.jp/contact/
 ### Bid parameters
 
 {: .table .table-bordered .table-striped }
-| Name       | Scope    | Description                                                       | Example                              | Type            |
-|------------|----------|-------------------------------------------------------------------|--------------------------------------|-----------------|
-| `spot`     | required | Ad placement ID provided by MicroAd.                              | `'209e56872ae8b0442a60477ae0c58be9'` | `string`        |
-| `url`      | optional | URL parameter. Effective only when provided by MicroAd.           | `'${COMPASS_EXT_URL}'`               | `string`        |
-| `referrer` | optional | Referrer parameter. Effective only when provided by MicroAd.      | `'${COMPASS_EXT_REF}'`               | `string`        |
-| `ifa`      | optional | IFA parameter. Effective only when provided by MicroAd.           | `'${COMPASS_EXT_IFA}'`               | `string`        |
-| `appid`    | optional | App ID parameter. Effective only when provided by MicroAd.        | `'${COMPASS_EXT_APPID}'`             | `string`        |
-| `geo`      | optional | Geo parameter. Effective only when provided by MicroAd.           | `'${COMPASS_EXT_GEO}'`               | `string`        |
-| `aids`     | optional | User IDs parameter. `type` indicates User IDs type.               | `[{type: 6, id: '*******'}]`         | `Array<Object>` |
+| Name           | Scope    | Description                                                           | Example                              | Type            |
+|------------    |----------|-------------------------------------------------------------------    |--------------------------------------|-----------------|
+| `spot`         | required | Ad placement ID provided by MicroAd.                                  | `'209e56872ae8b0442a60477ae0c58be9'` | `string`        |
+| `url`          | optional | URL parameter. Effective only when provided by MicroAd.               | `'${COMPASS_EXT_URL}'`               | `string`        |
+| `referrer`     | optional | Referrer parameter. Effective only when provided by MicroAd.          | `'${COMPASS_EXT_REF}'`               | `string`        |
+| `ifa`          | optional | IFA parameter. Effective only when provided by MicroAd.               | `'${COMPASS_EXT_IFA}'`               | `string`        |
+| `appid`        | optional | App ID parameter. Effective only when provided by MicroAd.            | `'${COMPASS_EXT_APPID}'`             | `string`        |
+| `geo`          | optional | Geo parameter. Effective only when provided by MicroAd.               | `'${COMPASS_EXT_GEO}'`               | `string`        |
+| `aids`         | optional | User IDs parameter. `type` indicates User IDs type.                   | `[{type: 6, id: '*******'}]`         | `Array<Object>` |
+| `gpid`         | optional | Global Placement ID.                                                  | `/1111/home-left`                    | `string`        |
+| `adservname`   | optional | If GPT slot matching succeeds, it sets 'gam'.                         | `gam`                                | `string`        |
+| `adservadslot` | optional | If GPT slot matching succeeds, it copies the resulting GPT slot name. | `/1111/home`                         | `string`        |
+| `pbadslot`     | optional | Prebid ad slot.                                                       | `/1111/home-left`                    | `string`        |


### PR DESCRIPTION
## 概要
[Prebid.jsのMicroadドキュメント](https://docs.prebid.org/dev-docs/bidders/microad.html)に以下の4項目を追加しました。
- gpid
- adservname
- adservadslot
- pbadslot

## 変更点
下記のPrebid.jsドキュメントの英文を参考にしました。
差分が多くなっているのは空白を追加して列を揃えたためです。追加したのは上記4項目だけです。
https://docs.prebid.org/dev-docs/modules/gpt-pre-auction.html
https://docs.prebid.org/features/pbAdSlot.html